### PR TITLE
Create a distinct build path for docker to prevent compilation issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,11 +78,15 @@ build: promu
 	@echo ">> building binaries"
 	@$(PROMU) build --prefix $(PREFIX)
 
+build-linux-amd64: promu
+	@echo ">> building linux amd64 binaries"
+	@GOOS=linux GOARCH=amd64 $(PROMU) build --prefix $(PREFIX)
+
 tarball: promu
 	@echo ">> building release tarball"
 	@$(PROMU) tarball --prefix $(PREFIX) $(BIN_DIR)
 
-docker: build
+docker: build-linux-amd64
 	@echo ">> building docker image"
 	@docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
 


### PR DESCRIPTION
This PR resolves that `make docker`, up until now, has only produced a viable docker image when the host was ALSO `linux/amd64`. 

If I am an OSx user, and I used `make build`, that would provide a suitable binary for me on OSx, but it would not provide a suitable binary for the base docker image `quay.io/prometheus/busybox:latest`.

Creating a distinct `make build-linux-amd64`, and having `make docker` depend on that step ensures that the produced docker image will be able to run on `quay.io/prometheus/busybox:latest` without issue.