### PR TITLE
Fixing nil pointer dereference

### DIFF
--- a/retrieval/scrape.go
+++ b/retrieval/scrape.go
@@ -962,6 +962,8 @@ func subtractResetValue(resetValue PointValue, metric *dto.Metric) {
 	}
 	if resetValue.Summary.Count > 0 {
 		*metric.Summary.SampleCount -= resetValue.Summary.Count
-		*metric.Summary.SampleSum -= resetValue.Summary.Sum
+ 		if metric.Summary.SampleSum != nil {
+			*metric.Summary.SampleSum -= resetValue.Summary.Sum
+ 		}
 	}
 }


### PR DESCRIPTION
which can happen in the _sum metric is missing.

Some prometheus exporters are not exposing the `_sum` metric of a summary which will cause the parser to crash. I believe it is the root cause of #5.

I added a test based on `TestPointExtractor` that exposes the issue. It is just a quick copy&paste to expose the issue and I'd welcome some feddback to make it less noisy 😉 .

I also added a check to make sure that the `metric.Summary.SampleSum` is not nil when we try to decrement the `resetValue` from it. I'm not sure it is the best way to solve the issue, but I ran the code in my cluster and it seems to solve the problem.