### PR TITLE
Make metric prefix configurable and make project information config optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ STATICCHECK_IGNORE = \
   github.com/prometheus/prometheus/pkg/textparse/lex.l.go:SA4006 \
   github.com/prometheus/prometheus/pkg/pool/pool.go:SA6002 \
   github.com/prometheus/prometheus/promql/engine.go:SA6002 \
-  github.com/prometheus/prometheus/web/web.go:SA1019
+  github.com/prometheus/prometheus/web/web.go:SA1019 \
+  github.com/Stackdriver/stackdriver-prometheus/stackdriver/storage.go:SA4006
 
 all: format staticcheck build test
 

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -103,6 +103,10 @@ func main() {
 		"Whether to export Stackdriver k8s_* resource types, otherwise export gke_container.").
 		Default("true").BoolVar(&cfg.sdCfg.K8sResourceTypes)
 
+	a.Flag("stackdriver.metric-prefix",
+		"Prefix for all metrics written to Stackdriver.").
+		Default("external.googleapis.com/prometheus").StringVar(&cfg.sdCfg.MetricPrefix)
+
 	a.Flag("web.listen-address", "Address to listen on for UI, API, and telemetry.").
 		Default("0.0.0.0:9090").StringVar(&cfg.web.ListenAddress)
 

--- a/stackdriver/client.go
+++ b/stackdriver/client.go
@@ -38,7 +38,6 @@ import (
 )
 
 const (
-	metricsPrefix             = "external.googleapis.com/prometheus"
 	maxTimeseriesesPerRequest = 200
 	MonitoringWriteScope      = "https://www.googleapis.com/auth/monitoring.write"
 )
@@ -47,21 +46,25 @@ const (
 // implementation may hit a single backend, so the application should create a
 // number of these clients.
 type Client struct {
-	index     int // Used to differentiate clients in metrics.
-	logger    log.Logger
-	projectId string
-	url       *config_util.URL
-	timeout   time.Duration
+	index       int // Used to differentiate clients in metrics.
+	logger      log.Logger
+	projectId   string
+	clusterName string
+	location    string
+	url         *config_util.URL
+	timeout     time.Duration
 
 	conn *grpc.ClientConn
 }
 
 // ClientConfig configures a Client.
 type ClientConfig struct {
-	Logger    log.Logger
-	ProjectId string // The Stackdriver project id in "projects/name-or-number" format.
-	URL       *config_util.URL
-	Timeout   model.Duration
+	Logger      log.Logger
+	ProjectId   string // The Stackdriver project id in "projects/name-or-number" format.
+	ClusterName string
+	Location    string
+	URL         *config_util.URL
+	Timeout     model.Duration
 }
 
 // NewClient creates a new Client.
@@ -71,11 +74,13 @@ func NewClient(index int, conf *ClientConfig) *Client {
 		logger = log.NewNopLogger()
 	}
 	return &Client{
-		index:     index,
-		logger:    logger,
-		projectId: conf.ProjectId,
-		url:       conf.URL,
-		timeout:   time.Duration(conf.Timeout),
+		index:       index,
+		logger:      logger,
+		projectId:   conf.ProjectId,
+		clusterName: conf.ClusterName,
+		location:    conf.Location,
+		url:         conf.URL,
+		timeout:     time.Duration(conf.Timeout),
 	}
 }
 

--- a/stackdriver/config.go
+++ b/stackdriver/config.go
@@ -18,10 +18,14 @@ package stackdriver
 type StackdriverConfig struct {
 	// Whether to export Stackdriver k8s_* resource types or gke_container. The former require joining an early-access program.
 	K8sResourceTypes bool
+
+	// Prefix for all metrics.
+	MetricPrefix string
 }
 
 var (
 	DefaultStackdriverConfig = StackdriverConfig{
 		K8sResourceTypes: false,
+		MetricPrefix:     "external.googleapis.com/prometheus",
 	}
 )

--- a/stackdriver/queue_manager.go
+++ b/stackdriver/queue_manager.go
@@ -155,6 +155,7 @@ type QueueManager struct {
 	queueName        string
 	logLimiter       *rate.Limiter
 	resourceMappings []ResourceMap
+	metricPrefix     string
 
 	shardsMtx   sync.RWMutex
 	shards      *shardCollection
@@ -188,6 +189,7 @@ func NewQueueManager(logger log.Logger, cfg config.QueueConfig, externalLabelSet
 		clientFactory:    clientFactory,
 		queueName:        clientFactory.Name(),
 		resourceMappings: resourceMappings,
+		metricPrefix:     sdCfg.MetricPrefix,
 
 		logLimiter:  rate.NewLimiter(logRateLimit, logBurst),
 		numShards:   1,
@@ -421,7 +423,7 @@ func (t *QueueManager) newShardCollection(numShards int) *shardCollection {
 	}
 	s := &shardCollection{
 		qm:         t,
-		translator: NewTranslator(t.logger, metricsPrefix, t.resourceMappings),
+		translator: NewTranslator(t.logger, t.metricPrefix, t.resourceMappings),
 		shards:     shards,
 		done:       make(chan struct{}),
 	}

--- a/stackdriver/queue_manager_test.go
+++ b/stackdriver/queue_manager_test.go
@@ -141,7 +141,7 @@ func (c *TestStorageClient) Store(req *monitoring.CreateTimeSeriesRequest) error
 		seenTimeSeries[fp] = struct{}{}
 		metricType := ts.Metric.Type
 		// Remove the Stackdriver "domain/" prefix which isn't present in the test input.
-		name := metricType[len(DefaultStackdriverConfig.MetricPrefix)+1:]
+		name := metricType[c.prefixLen+1:]
 		for _, point := range ts.Points {
 			count++
 			startTime := point.GetInterval().GetStartTime()
@@ -317,13 +317,14 @@ func TestDeliveryWithMetricPrefix(t *testing.T) {
 	}
 
 	c := NewTestStorageClient(t)
-	c.prefixLen = 4
+	prefix := "abc/"
+	c.prefixLen = len(prefix)
 	c.expectSamples(samples)
 
 	cfg := config.DefaultQueueConfig
 	cfg.Capacity = n
 	cfg.MaxSamplesPerSend = n
-	m := NewQueueManager(nil, cfg, nil, nil, c, &StackdriverConfig{false, "abc/"})
+	m := NewQueueManager(nil, cfg, nil, nil, c, &StackdriverConfig{false, prefix})
 
 	// These should be received by the client.
 	for _, s := range samples {

--- a/stackdriver/resource_map.go
+++ b/stackdriver/resource_map.go
@@ -22,7 +22,9 @@ import (
 )
 
 const (
-	ProjectIdLabel = "_stackdriver_project_id"
+	ProjectIdLabel   = "_stackdriver_project_id"
+	LocationLabel    = "_kubernetes_location"
+	ClusterNameLabel = "_kubernetes_cluster_name"
 )
 
 // TODO(jkohen): ensure these are sorted from more specific to less specific.
@@ -32,8 +34,8 @@ var DefaultResourceMappings = []ResourceMap{
 		Type: "gke_container",
 		LabelMap: map[string]string{
 			ProjectIdLabel:                   "project_id",
-			"_kubernetes_location":           "zone",
-			"_kubernetes_cluster_name":       "cluster_name",
+			LocationLabel:                    "zone",
+			ClusterNameLabel:                 "cluster_name",
 			"_kubernetes_namespace":          "namespace_id",
 			"_kubernetes_pod_name":           "pod_id",
 			"_kubernetes_pod_node_name":      "instance_id",
@@ -48,8 +50,8 @@ var K8sResourceMappings = []ResourceMap{
 		Type: "k8s_container",
 		LabelMap: map[string]string{
 			ProjectIdLabel:                         "project_id",
-			"_kubernetes_location":                 "location",
-			"_kubernetes_cluster_name":             "cluster_name",
+			LocationLabel:                          "location",
+			ClusterNameLabel:                       "cluster_name",
 			"__meta_kubernetes_namespace":          "namespace_name",
 			"__meta_kubernetes_pod_name":           "pod_name",
 			"__meta_kubernetes_pod_container_name": "container_name",
@@ -59,8 +61,8 @@ var K8sResourceMappings = []ResourceMap{
 		Type: "k8s_pod",
 		LabelMap: map[string]string{
 			ProjectIdLabel:                "project_id",
-			"_kubernetes_location":        "location",
-			"_kubernetes_cluster_name":    "cluster_name",
+			LocationLabel:                 "location",
+			ClusterNameLabel:              "cluster_name",
 			"__meta_kubernetes_namespace": "namespace_name",
 			"__meta_kubernetes_pod_name":  "pod_name",
 		},
@@ -69,9 +71,17 @@ var K8sResourceMappings = []ResourceMap{
 		Type: "k8s_node",
 		LabelMap: map[string]string{
 			ProjectIdLabel:                "project_id",
-			"_kubernetes_location":        "location",
-			"_kubernetes_cluster_name":    "cluster_name",
+			LocationLabel:                 "location",
+			ClusterNameLabel:              "cluster_name",
 			"__meta_kubernetes_node_name": "node_name",
+		},
+	},
+	{
+		Type: "k8s_cluster",
+		LabelMap: map[string]string{
+			ProjectIdLabel:   "project_id",
+			LocationLabel:    "location",
+			ClusterNameLabel: "cluster_name",
 		},
 	},
 }

--- a/stackdriver/storage.go
+++ b/stackdriver/storage.go
@@ -17,6 +17,7 @@ package stackdriver
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	md "cloud.google.com/go/compute/metadata"
@@ -77,16 +78,19 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 	if md.OnGCE() {
 		if el[ProjectIdLabel] == "" {
 			if id, err := md.ProjectID(); err == nil {
+				strings.TrimSpace(id)
 				el[ProjectIdLabel] = model.LabelValue(id)
 			}
 		}
 		if el[LocationLabel] == "" {
 			if l, err := md.InstanceAttributeValue("cluster-location"); err == nil {
+				strings.TrimSpace(l)
 				el[LocationLabel] = model.LabelValue(l)
 			}
 		}
 		if el[ClusterNameLabel] == "" {
 			if cn, err := md.InstanceAttributeValue("cluster-name"); err == nil {
+				strings.TrimSpace(cn)
 				el[ClusterNameLabel] = model.LabelValue(cn)
 			}
 		}

--- a/stackdriver/storage.go
+++ b/stackdriver/storage.go
@@ -78,19 +78,19 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 	if md.OnGCE() {
 		if el[ProjectIdLabel] == "" {
 			if id, err := md.ProjectID(); err == nil {
-				strings.TrimSpace(id)
+				id = strings.TrimSpace(id)
 				el[ProjectIdLabel] = model.LabelValue(id)
 			}
 		}
 		if el[LocationLabel] == "" {
 			if l, err := md.InstanceAttributeValue("cluster-location"); err == nil {
-				strings.TrimSpace(l)
+				l = strings.TrimSpace(l)
 				el[LocationLabel] = model.LabelValue(l)
 			}
 		}
 		if el[ClusterNameLabel] == "" {
 			if cn, err := md.InstanceAttributeValue("cluster-name"); err == nil {
-				strings.TrimSpace(cn)
+				cn = strings.TrimSpace(cn)
 				el[ClusterNameLabel] = model.LabelValue(cn)
 			}
 		}

--- a/stackdriver/storage.go
+++ b/stackdriver/storage.go
@@ -77,21 +77,18 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 	var clusterName string
 	el := conf.GlobalConfig.ExternalLabels
 	if md.OnGCE() {
-		if id, err := md.ProjectID(); err == nil {
-			projectId = "projects/" + id
-			if v, ok := el[ProjectIdLabel]; !ok || v == "" {
+		if el[ProjectIdLabel] == "" {
+			if id, err := md.ProjectID(); err == nil {
 				el[ProjectIdLabel] = model.LabelValue(id)
 			}
 		}
-		if l, err := md.InstanceAttributeValue("cluster-location"); err == nil {
-			location = l
-			if v, ok := el[LocationLabel]; !ok || v == "" {
+		if el[LocationLabel] == "" {
+			if l, err := md.InstanceAttributeValue("cluster-location"); err == nil {
 				el[LocationLabel] = model.LabelValue(l)
 			}
 		}
-		if cn, err := md.InstanceAttributeValue("cluster-name"); err == nil {
-			clusterName = cn
-			if v, ok := el[ClusterNameLabel]; !ok || v == "" {
+		if el[ClusterNameLabel] == "" {
+			if cn, err := md.InstanceAttributeValue("cluster-name"); err == nil {
 				el[ClusterNameLabel] = model.LabelValue(cn)
 			}
 		}

--- a/stackdriver/storage.go
+++ b/stackdriver/storage.go
@@ -73,8 +73,6 @@ func (s *Storage) Close() error {
 // ApplyConfig updates the state as the new config requires.
 func (s *Storage) ApplyConfig(conf *config.Config) error {
 	var projectId string
-	var location string
-	var clusterName string
 	el := conf.GlobalConfig.ExternalLabels
 	if md.OnGCE() {
 		if el[ProjectIdLabel] == "" {
@@ -118,8 +116,8 @@ func (s *Storage) ApplyConfig(conf *config.Config) error {
 			&clientFactory{
 				logger:      s.logger,
 				projectId:   projectId,
-				location:    location,
-				clusterName: clusterName,
+				location:    string(el[LocationLabel]),
+				clusterName: string(el[ClusterNameLabel]),
 				url:         rwConf.URL,
 				timeout:     rwConf.RemoteTimeout,
 				index:       i,

--- a/vendor/cloud.google.com/go/LICENSE
+++ b/vendor/cloud.google.com/go/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/cloud.google.com/go/compute/metadata/metadata.go
+++ b/vendor/cloud.google.com/go/compute/metadata/metadata.go
@@ -1,0 +1,503 @@
+// Copyright 2014 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metadata provides access to Google Compute Engine (GCE)
+// metadata and API service accounts.
+//
+// This package is a wrapper around the GCE metadata service,
+// as documented at https://developers.google.com/compute/docs/metadata.
+package metadata // import "cloud.google.com/go/compute/metadata"
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+	"golang.org/x/net/context/ctxhttp"
+)
+
+const (
+	// metadataIP is the documented metadata server IP address.
+	metadataIP = "169.254.169.254"
+
+	// metadataHostEnv is the environment variable specifying the
+	// GCE metadata hostname.  If empty, the default value of
+	// metadataIP ("169.254.169.254") is used instead.
+	// This is variable name is not defined by any spec, as far as
+	// I know; it was made up for the Go package.
+	metadataHostEnv = "GCE_METADATA_HOST"
+
+	userAgent = "gcloud-golang/0.1"
+)
+
+type cachedValue struct {
+	k    string
+	trim bool
+	mu   sync.Mutex
+	v    string
+}
+
+var (
+	projID  = &cachedValue{k: "project/project-id", trim: true}
+	projNum = &cachedValue{k: "project/numeric-project-id", trim: true}
+	instID  = &cachedValue{k: "instance/id", trim: true}
+)
+
+var (
+	defaultClient = &Client{hc: &http.Client{
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   2 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).Dial,
+			ResponseHeaderTimeout: 2 * time.Second,
+		},
+	}}
+	subscribeClient = &Client{hc: &http.Client{
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   2 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).Dial,
+		},
+	}}
+)
+
+// NotDefinedError is returned when requested metadata is not defined.
+//
+// The underlying string is the suffix after "/computeMetadata/v1/".
+//
+// This error is not returned if the value is defined to be the empty
+// string.
+type NotDefinedError string
+
+func (suffix NotDefinedError) Error() string {
+	return fmt.Sprintf("metadata: GCE metadata %q not defined", string(suffix))
+}
+
+func (c *cachedValue) get(cl *Client) (v string, err error) {
+	defer c.mu.Unlock()
+	c.mu.Lock()
+	if c.v != "" {
+		return c.v, nil
+	}
+	if c.trim {
+		v, err = cl.getTrimmed(c.k)
+	} else {
+		v, err = cl.Get(c.k)
+	}
+	if err == nil {
+		c.v = v
+	}
+	return
+}
+
+var (
+	onGCEOnce sync.Once
+	onGCE     bool
+)
+
+// OnGCE reports whether this process is running on Google Compute Engine.
+func OnGCE() bool {
+	onGCEOnce.Do(initOnGCE)
+	return onGCE
+}
+
+func initOnGCE() {
+	onGCE = testOnGCE()
+}
+
+func testOnGCE() bool {
+	// The user explicitly said they're on GCE, so trust them.
+	if os.Getenv(metadataHostEnv) != "" {
+		return true
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resc := make(chan bool, 2)
+
+	// Try two strategies in parallel.
+	// See https://github.com/GoogleCloudPlatform/google-cloud-go/issues/194
+	go func() {
+		req, _ := http.NewRequest("GET", "http://"+metadataIP, nil)
+		req.Header.Set("User-Agent", userAgent)
+		res, err := ctxhttp.Do(ctx, defaultClient.hc, req)
+		if err != nil {
+			resc <- false
+			return
+		}
+		defer res.Body.Close()
+		resc <- res.Header.Get("Metadata-Flavor") == "Google"
+	}()
+
+	go func() {
+		addrs, err := net.LookupHost("metadata.google.internal")
+		if err != nil || len(addrs) == 0 {
+			resc <- false
+			return
+		}
+		resc <- strsContains(addrs, metadataIP)
+	}()
+
+	tryHarder := systemInfoSuggestsGCE()
+	if tryHarder {
+		res := <-resc
+		if res {
+			// The first strategy succeeded, so let's use it.
+			return true
+		}
+		// Wait for either the DNS or metadata server probe to
+		// contradict the other one and say we are running on
+		// GCE. Give it a lot of time to do so, since the system
+		// info already suggests we're running on a GCE BIOS.
+		timer := time.NewTimer(5 * time.Second)
+		defer timer.Stop()
+		select {
+		case res = <-resc:
+			return res
+		case <-timer.C:
+			// Too slow. Who knows what this system is.
+			return false
+		}
+	}
+
+	// There's no hint from the system info that we're running on
+	// GCE, so use the first probe's result as truth, whether it's
+	// true or false. The goal here is to optimize for speed for
+	// users who are NOT running on GCE. We can't assume that
+	// either a DNS lookup or an HTTP request to a blackholed IP
+	// address is fast. Worst case this should return when the
+	// metaClient's Transport.ResponseHeaderTimeout or
+	// Transport.Dial.Timeout fires (in two seconds).
+	return <-resc
+}
+
+// systemInfoSuggestsGCE reports whether the local system (without
+// doing network requests) suggests that we're running on GCE. If this
+// returns true, testOnGCE tries a bit harder to reach its metadata
+// server.
+func systemInfoSuggestsGCE() bool {
+	if runtime.GOOS != "linux" {
+		// We don't have any non-Linux clues available, at least yet.
+		return false
+	}
+	slurp, _ := ioutil.ReadFile("/sys/class/dmi/id/product_name")
+	name := strings.TrimSpace(string(slurp))
+	return name == "Google" || name == "Google Compute Engine"
+}
+
+// Subscribe calls Client.Subscribe on a client designed for subscribing (one with no
+// ResponseHeaderTimeout).
+func Subscribe(suffix string, fn func(v string, ok bool) error) error {
+	return subscribeClient.Subscribe(suffix, fn)
+}
+
+// Get calls Client.Get on the default client.
+func Get(suffix string) (string, error) { return defaultClient.Get(suffix) }
+
+// ProjectID returns the current instance's project ID string.
+func ProjectID() (string, error) { return defaultClient.ProjectID() }
+
+// NumericProjectID returns the current instance's numeric project ID.
+func NumericProjectID() (string, error) { return defaultClient.NumericProjectID() }
+
+// InternalIP returns the instance's primary internal IP address.
+func InternalIP() (string, error) { return defaultClient.InternalIP() }
+
+// ExternalIP returns the instance's primary external (public) IP address.
+func ExternalIP() (string, error) { return defaultClient.ExternalIP() }
+
+// Hostname returns the instance's hostname. This will be of the form
+// "<instanceID>.c.<projID>.internal".
+func Hostname() (string, error) { return defaultClient.Hostname() }
+
+// InstanceTags returns the list of user-defined instance tags,
+// assigned when initially creating a GCE instance.
+func InstanceTags() ([]string, error) { return defaultClient.InstanceTags() }
+
+// InstanceID returns the current VM's numeric instance ID.
+func InstanceID() (string, error) { return defaultClient.InstanceID() }
+
+// InstanceName returns the current VM's instance ID string.
+func InstanceName() (string, error) { return defaultClient.InstanceName() }
+
+// Zone returns the current VM's zone, such as "us-central1-b".
+func Zone() (string, error) { return defaultClient.Zone() }
+
+// InstanceAttributes calls Client.InstanceAttributes on the default client.
+func InstanceAttributes() ([]string, error) { return defaultClient.InstanceAttributes() }
+
+// ProjectAttributes calls Client.ProjectAttributes on the default client.
+func ProjectAttributes() ([]string, error) { return defaultClient.ProjectAttributes() }
+
+// InstanceAttributeValue calls Client.InstanceAttributeValue on the default client.
+func InstanceAttributeValue(attr string) (string, error) {
+	return defaultClient.InstanceAttributeValue(attr)
+}
+
+// ProjectAttributeValue calls Client.ProjectAttributeValue on the default client.
+func ProjectAttributeValue(attr string) (string, error) {
+	return defaultClient.ProjectAttributeValue(attr)
+}
+
+// Scopes calls Client.Scopes on the default client.
+func Scopes(serviceAccount string) ([]string, error) { return defaultClient.Scopes(serviceAccount) }
+
+func strsContains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// A Client provides metadata.
+type Client struct {
+	hc *http.Client
+}
+
+// NewClient returns a Client that can be used to fetch metadata. All HTTP requests
+// will use the given http.Client instead of the default client.
+func NewClient(c *http.Client) *Client {
+	return &Client{hc: c}
+}
+
+// getETag returns a value from the metadata service as well as the associated ETag.
+// This func is otherwise equivalent to Get.
+func (c *Client) getETag(suffix string) (value, etag string, err error) {
+	// Using a fixed IP makes it very difficult to spoof the metadata service in
+	// a container, which is an important use-case for local testing of cloud
+	// deployments. To enable spoofing of the metadata service, the environment
+	// variable GCE_METADATA_HOST is first inspected to decide where metadata
+	// requests shall go.
+	host := os.Getenv(metadataHostEnv)
+	if host == "" {
+		// Using 169.254.169.254 instead of "metadata" here because Go
+		// binaries built with the "netgo" tag and without cgo won't
+		// know the search suffix for "metadata" is
+		// ".google.internal", and this IP address is documented as
+		// being stable anyway.
+		host = metadataIP
+	}
+	url := "http://" + host + "/computeMetadata/v1/" + suffix
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Metadata-Flavor", "Google")
+	req.Header.Set("User-Agent", userAgent)
+	res, err := c.hc.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer res.Body.Close()
+	if res.StatusCode == http.StatusNotFound {
+		return "", "", NotDefinedError(suffix)
+	}
+	if res.StatusCode != 200 {
+		return "", "", fmt.Errorf("status code %d trying to fetch %s", res.StatusCode, url)
+	}
+	all, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", "", err
+	}
+	return string(all), res.Header.Get("Etag"), nil
+}
+
+// Get returns a value from the metadata service.
+// The suffix is appended to "http://${GCE_METADATA_HOST}/computeMetadata/v1/".
+//
+// If the GCE_METADATA_HOST environment variable is not defined, a default of
+// 169.254.169.254 will be used instead.
+//
+// If the requested metadata is not defined, the returned error will
+// be of type NotDefinedError.
+func (c *Client) Get(suffix string) (string, error) {
+	val, _, err := c.getETag(suffix)
+	return val, err
+}
+
+func (c *Client) getTrimmed(suffix string) (s string, err error) {
+	s, err = c.Get(suffix)
+	s = strings.TrimSpace(s)
+	return
+}
+
+func (c *Client) lines(suffix string) ([]string, error) {
+	j, err := c.Get(suffix)
+	if err != nil {
+		return nil, err
+	}
+	s := strings.Split(strings.TrimSpace(j), "\n")
+	for i := range s {
+		s[i] = strings.TrimSpace(s[i])
+	}
+	return s, nil
+}
+
+// ProjectID returns the current instance's project ID string.
+func (c *Client) ProjectID() (string, error) { return projID.get(c) }
+
+// NumericProjectID returns the current instance's numeric project ID.
+func (c *Client) NumericProjectID() (string, error) { return projNum.get(c) }
+
+// InstanceID returns the current VM's numeric instance ID.
+func (c *Client) InstanceID() (string, error) { return instID.get(c) }
+
+// InternalIP returns the instance's primary internal IP address.
+func (c *Client) InternalIP() (string, error) {
+	return c.getTrimmed("instance/network-interfaces/0/ip")
+}
+
+// ExternalIP returns the instance's primary external (public) IP address.
+func (c *Client) ExternalIP() (string, error) {
+	return c.getTrimmed("instance/network-interfaces/0/access-configs/0/external-ip")
+}
+
+// Hostname returns the instance's hostname. This will be of the form
+// "<instanceID>.c.<projID>.internal".
+func (c *Client) Hostname() (string, error) {
+	return c.getTrimmed("instance/hostname")
+}
+
+// InstanceTags returns the list of user-defined instance tags,
+// assigned when initially creating a GCE instance.
+func (c *Client) InstanceTags() ([]string, error) {
+	var s []string
+	j, err := c.Get("instance/tags")
+	if err != nil {
+		return nil, err
+	}
+	if err := json.NewDecoder(strings.NewReader(j)).Decode(&s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// InstanceName returns the current VM's instance ID string.
+func (c *Client) InstanceName() (string, error) {
+	host, err := c.Hostname()
+	if err != nil {
+		return "", err
+	}
+	return strings.Split(host, ".")[0], nil
+}
+
+// Zone returns the current VM's zone, such as "us-central1-b".
+func (c *Client) Zone() (string, error) {
+	zone, err := c.getTrimmed("instance/zone")
+	// zone is of the form "projects/<projNum>/zones/<zoneName>".
+	if err != nil {
+		return "", err
+	}
+	return zone[strings.LastIndex(zone, "/")+1:], nil
+}
+
+// InstanceAttributes returns the list of user-defined attributes,
+// assigned when initially creating a GCE VM instance. The value of an
+// attribute can be obtained with InstanceAttributeValue.
+func (c *Client) InstanceAttributes() ([]string, error) { return c.lines("instance/attributes/") }
+
+// ProjectAttributes returns the list of user-defined attributes
+// applying to the project as a whole, not just this VM.  The value of
+// an attribute can be obtained with ProjectAttributeValue.
+func (c *Client) ProjectAttributes() ([]string, error) { return c.lines("project/attributes/") }
+
+// InstanceAttributeValue returns the value of the provided VM
+// instance attribute.
+//
+// If the requested attribute is not defined, the returned error will
+// be of type NotDefinedError.
+//
+// InstanceAttributeValue may return ("", nil) if the attribute was
+// defined to be the empty string.
+func (c *Client) InstanceAttributeValue(attr string) (string, error) {
+	return c.Get("instance/attributes/" + attr)
+}
+
+// ProjectAttributeValue returns the value of the provided
+// project attribute.
+//
+// If the requested attribute is not defined, the returned error will
+// be of type NotDefinedError.
+//
+// ProjectAttributeValue may return ("", nil) if the attribute was
+// defined to be the empty string.
+func (c *Client) ProjectAttributeValue(attr string) (string, error) {
+	return c.Get("project/attributes/" + attr)
+}
+
+// Scopes returns the service account scopes for the given account.
+// The account may be empty or the string "default" to use the instance's
+// main account.
+func (c *Client) Scopes(serviceAccount string) ([]string, error) {
+	if serviceAccount == "" {
+		serviceAccount = "default"
+	}
+	return c.lines("instance/service-accounts/" + serviceAccount + "/scopes")
+}
+
+// Subscribe subscribes to a value from the metadata service.
+// The suffix is appended to "http://${GCE_METADATA_HOST}/computeMetadata/v1/".
+// The suffix may contain query parameters.
+//
+// Subscribe calls fn with the latest metadata value indicated by the provided
+// suffix. If the metadata value is deleted, fn is called with the empty string
+// and ok false. Subscribe blocks until fn returns a non-nil error or the value
+// is deleted. Subscribe returns the error value returned from the last call to
+// fn, which may be nil when ok == false.
+func (c *Client) Subscribe(suffix string, fn func(v string, ok bool) error) error {
+	const failedSubscribeSleep = time.Second * 5
+
+	// First check to see if the metadata value exists at all.
+	val, lastETag, err := c.getETag(suffix)
+	if err != nil {
+		return err
+	}
+
+	if err := fn(val, true); err != nil {
+		return err
+	}
+
+	ok := true
+	if strings.ContainsRune(suffix, '?') {
+		suffix += "&wait_for_change=true&last_etag="
+	} else {
+		suffix += "?wait_for_change=true&last_etag="
+	}
+	for {
+		val, etag, err := c.getETag(suffix + url.QueryEscape(lastETag))
+		if err != nil {
+			if _, deleted := err.(NotDefinedError); !deleted {
+				time.Sleep(failedSubscribeSleep)
+				continue // Retry on other errors.
+			}
+			ok = false
+		}
+		lastETag = etag
+
+		if err := fn(val, ok); err != nil || !ok {
+			return err
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "j/0+O4eJ99Jrb9un/bwi5npLyOM=",
+			"path": "cloud.google.com/go/compute/metadata",
+			"revision": "5f0ffe7729373c98a5801de148565a893a0d2899",
+			"revisionTime": "2018-10-10T17:36:19Z"
+		},
+		{
 			"checksumSHA1": "oIt4tXgFYnZJBsCac1BQLnTWALM=",
 			"path": "github.com/Azure/azure-sdk-for-go/arm/compute",
 			"revision": "bd73d950fa4440dae889bd9917bff7cef539f86e",


### PR DESCRIPTION
Also fetch project metadata (project id, cluster, location) from metadata server to avoid customized config.

@ostromart